### PR TITLE
Added missing public function to expose power renegotiation

### DIFF
--- a/include/policy_engine.h
+++ b/include/policy_engine.h
@@ -109,6 +109,8 @@ public:
     return (int)state;
   }
 
+  inline void renegotiate() { notify(Notifications::NEW_POWER); }
+
 private:
   const FUSB302                   fusb;
   const TimestampFunc             getTimeStamp;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The changes have been tested locally
- [X] There are no breaking changes

* **What kind of change does this PR introduce?**
* Adds a public inline function to the PolicyEngine class that simply calls notify(Notification::NEW_POWER) 

* **What is the current behavior?**
* There is currently no way to trigger a renegotiation

* **What is the new behavior (if this is a feature change)?**
* Allows user code to call pe.renegotiate(), and change power settings on the fly, instead of just once at startup

* **Other information**:
* #15
* I have tested the change within the IronOS project, and it still builds